### PR TITLE
Feat: Implement Self-settable Password and Improve Label Generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ frontend/.next/
 
 # Instance ID
 .instance_id 
+
+.auth_password.key
+.key

--- a/README.md
+++ b/README.md
@@ -32,13 +32,7 @@ Only **gmail** (either personal or workspace) is supported. Support for Outlook 
 4. Use `docker-compose up` to start the updated server
 
 ### Securing Your Installation
-By default, your Brewdock instance is accessible to anyone on your network (or on the public internet if deployed to a VPS). You can secure it with a simple password.
-
-1. Open your `.env` file.
-2. Find the `AUTH_PASSWORD=` line.
-3. Add a secure password to it, for example: `AUTH_PASSWORD=your_secret_password`
-
-If `AUTH_PASSWORD` is set, users will be prompted to enter this password before they can access the web interface. If it is left blank, authentication is disabled.
+By default, your Brewdock instance is accessible to anyone on your network. It is highly recommended to secure your installation with a password. For detailed instructions on how to set up a password, please see the guide here: [**Securing Your Installation**](documentation/set_passwords.md)
 
 ## Feedback and Feature Requests
 

--- a/api/endpoints/auth.py
+++ b/api/endpoints/auth.py
@@ -1,48 +1,169 @@
 import os
-from fastapi import APIRouter, Response, HTTPException, status
+from fastapi import APIRouter, Response, HTTPException, status, Depends
 from pydantic import BaseModel
 import secrets
 import hashlib
 import hmac
+from pathlib import Path
+
+from shared.security.encryption import encrypt_value, decrypt_value
 
 router = APIRouter(prefix="/auth", tags=["authentication"])
 
-AUTH_COOKIE_NAME = "min_interns_auth_session"
-AUTH_PASSWORD = os.getenv("AUTH_PASSWORD")
+# --- New Configuration ---
+AUTH_SELFSET_PASSWORD = os.getenv("AUTH_SELFSET_PASSWORD", "false").lower() == "true"
+# Use an absolute path within the container that corresponds to the mounted volume
+AUTH_PASSWORD_FILE_PATH = "/data/keys/auth_password.key"
+LEGACY_AUTH_PASSWORD = os.getenv("AUTH_PASSWORD")
+
+# Use a different cookie name for each auth method to prevent session bleed-over
+if AUTH_SELFSET_PASSWORD:
+    AUTH_COOKIE_NAME = "min_interns_auth_session_selfset"
+else:
+    AUTH_COOKIE_NAME = "min_interns_auth_session_legacy"
+
 # This salt should be a fixed, random string to ensure hash consistency.
 SESSION_SALT = "a1b2c3d4-e5f6-7890-a1b2-c3d4e5f67890"
 
-class LoginRequest(BaseModel):
-    password: str
+# --- Helper functions ---
 
-def get_session_token():
-    """Generates a verification token based on the auth password."""
-    if not AUTH_PASSWORD:
+async def get_password_from_file():
+    if not os.path.exists(AUTH_PASSWORD_FILE_PATH):
+        return None
+    try:
+        with open(AUTH_PASSWORD_FILE_PATH, mode='r') as f:
+            encrypted_password = f.read().strip()
+            if not encrypted_password:
+                return None
+            return decrypt_value(encrypted_password)
+    except FileNotFoundError:
+        return None
+
+def is_self_set_configured():
+    return os.path.exists(AUTH_PASSWORD_FILE_PATH)
+
+def get_auth_configuration_status():
+    if AUTH_SELFSET_PASSWORD:
+        if is_self_set_configured():
+            return "self_set_configured"
+        else:
+            return "self_set_unconfigured"
+    elif LEGACY_AUTH_PASSWORD:
+        return "legacy_configured"
+    else:
+        return "unconfigured"
+
+async def get_active_password():
+    """Gets the active password based on the configuration."""
+    if AUTH_SELFSET_PASSWORD:
+        return await get_password_from_file()
+    return LEGACY_AUTH_PASSWORD
+
+def get_session_token(password: str):
+    """Generates a verification token based on a given password."""
+    if not password:
         return None
     
     # This logic must exactly match the logic in the frontend middleware.
-    token_source = f"{SESSION_SALT}-{AUTH_PASSWORD}"
+    token_source = f"{SESSION_SALT}-{password}"
     salt_bytes = SESSION_SALT.encode()
     token_source_bytes = token_source.encode()
     
     return hmac.new(salt_bytes, token_source_bytes, hashlib.sha256).hexdigest()
 
+
+class LoginRequest(BaseModel):
+    password: str
+
+class SetPasswordRequest(BaseModel):
+    password: str
+
+class VerifyTokenRequest(BaseModel):
+    token: str
+
+
+@router.get("/status")
+async def auth_status():
+    """Returns the current authentication configuration status."""
+    return {"status": get_auth_configuration_status()}
+
+@router.post("/set-password")
+async def set_password(request: SetPasswordRequest, response: Response):
+    """
+    Sets the password for the first time when in self-set mode.
+    """
+    if get_auth_configuration_status() != "self_set_unconfigured":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Password has already been set or self-set mode is not enabled.",
+        )
+    
+    if not request.password or len(request.password) < 8:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Password must be at least 8 characters long.",
+        )
+
+    # Create directory if it doesn't exist, using the exact pattern from encryption.py
+    os.makedirs(os.path.dirname(AUTH_PASSWORD_FILE_PATH), exist_ok=True)
+    
+    encrypted_password = encrypt_value(request.password)
+    with open(AUTH_PASSWORD_FILE_PATH, mode='w') as f:
+        f.write(encrypted_password)
+    
+    # Log the user in immediately
+    session_token = get_session_token(request.password)
+    response.set_cookie(
+        key=AUTH_COOKIE_NAME,
+        value=session_token,
+        httponly=True,
+        secure=True, 
+        samesite='lax',
+        max_age=31536000,
+    )
+    return {"message": "Password set successfully."}
+
+
+@router.post("/verify")
+async def verify_token(request: VerifyTokenRequest, active_password: str = Depends(get_active_password)):
+    """
+    Verifies if a session token is still valid against the current password.
+    This is used by the middleware in self-set mode to ensure sessions are
+    invalidated if the password changes.
+    """
+    if not active_password:
+        return {"valid": False}
+
+    expected_token = get_session_token(active_password)
+    
+    # Use a secure comparison to prevent timing attacks
+    is_valid = secrets.compare_digest(request.token, expected_token)
+    return {"valid": is_valid}
+
+
 @router.post("/login")
-async def login(request: LoginRequest, response: Response):
+async def login(request: LoginRequest, response: Response, active_password: str = Depends(get_active_password)):
     """
     Authenticate a user and set a session cookie.
     """
-    if not AUTH_PASSWORD:
-        # This endpoint should not be used if auth is disabled
-        raise HTTPException(
+    auth_status = get_auth_configuration_status()
+
+    if auth_status == "unconfigured":
+         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Authentication is not enabled on the server.",
         )
+    
+    if auth_status == "self_set_unconfigured":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="A password has not been set for the application yet.",
+        )
 
-    if secrets.compare_digest(request.password, AUTH_PASSWORD):
+    if active_password and secrets.compare_digest(request.password, active_password):
         # Password is correct, set a secure, http-only cookie
         # Cookie expires in 1 year (31536000 seconds)
-        session_token = get_session_token()
+        session_token = get_session_token(active_password)
         response.set_cookie(
             key=AUTH_COOKIE_NAME,
             value=session_token,

--- a/documentation/PR_description_drafts/2025-07-11-v0.0.3-dev-Feat-Implement-self-settable-password-and-improve-label-generation.md
+++ b/documentation/PR_description_drafts/2025-07-11-v0.0.3-dev-Feat-Implement-self-settable-password-and-improve-label-generation.md
@@ -1,0 +1,42 @@
+### Title: Feat: Implement Self-settable Password and Improve Label Generation
+
+### Summary
+
+This pull request introduces a new authentication method allowing users to set their own password on the first run of the application. This enhances security and simplifies initial setup. Additionally, it refactors the label description generation logic to be more comprehensive and improves IMAP folder discovery.
+
+### Changes
+
+**Feature:**
+
+*   **Self-settable Password:**
+    *   Introduced a new `AUTH_SELFSET_PASSWORD` environment variable to enable a one-time, self-service password setup flow.
+    *   The password is encrypted and stored in `data/keys/auth_password.key`.
+    *   Relevant files: `api/endpoints/auth.py`, `frontend/middleware.ts`, `frontend/app/set-password/page.tsx`, `frontend/services/api.ts`.
+*   **New Authentication Endpoints:**
+    *   Added `/auth/status` to check the current authentication configuration.
+    *   Added `/auth/set-password` to allow the first user to set the instance password.
+    *   Added `/auth/verify` to validate session tokens against the currently active password.
+    *   Relevant file: `api/endpoints/auth.py`.
+
+**Refactor:**
+
+*   **Label Description Generation:**
+    *   The `generate_descriptions_for_agent` background task now overwrites existing labeling rules and populates them from all available inbox labels, ensuring descriptions are always generated for all user-defined labels.
+    *   Relevant file: `api/background_tasks/label_description_generator.py`.
+*   **IMAP Folder Discovery:**
+    *   Enhanced the `FolderResolver` to recognize more special-use folder attributes (e.g., `\Important`, `\Flagged`) and added fallbacks for non-English folder names (e.g., 'Verzonden').
+    *   Relevant file: `mcp_servers/imap_mcpserver/src/imap_client/internals/connection_manager.py`.
+
+**Documentation:**
+
+*   **Password Setup Guide:**
+    *   Created a new guide explaining the two authentication methods (fixed vs. self-set).
+    *   Relevant file: `documentation/set_passwords.md`.
+*   **README Update:**
+    *   Updated the main `README.md` to link to the new security documentation.
+
+**Chore:**
+
+*   **`.gitignore`:**
+    *   Added `.auth_password.key` and `.key` to prevent sensitive files from being committed.
+    *   Relevant file: `.gitignore`. 

--- a/documentation/PR_description_drafts/2025-07-11-v0.0.4dev-Feat-Implement-guided-setup-for-Email-Labeler-agent.md
+++ b/documentation/PR_description_drafts/2025-07-11-v0.0.4dev-Feat-Implement-guided-setup-for-Email-Labeler-agent.md
@@ -1,8 +1,5 @@
 ### Title: Feat: Implement guided setup for Email Labeler agent
 
-**Date:** 2025-07-11
-**Version:** 0.0.4dev
-
 ### Summary
 
 This pull request introduces a guided initialization process for the "Simple Email Labeler" agent. Instead of starting with pre-defined labels, the user is now prompted to either automatically generate label rules by scanning their inbox or to load a set of common examples. This change makes the agent more adaptive to the user's existing email organization. To support this, the underlying IMAP label detection has been refactored to be language-agnostic, correctly identifying user-defined labels by filtering out system folders.

--- a/documentation/set_passwords.md
+++ b/documentation/set_passwords.md
@@ -1,0 +1,49 @@
+# Securing Your Brewdock Installation
+
+By default, your Brewdock instance is accessible to anyone on your network. It is highly recommended to secure it with a password. There are two methods to do this, controlled by environment variables in your `.env` file.
+
+---
+
+### Method 1: Fixed Password (Recommended)
+
+This method uses a single, fixed password that you set in your configuration files. It is the simplest and most direct way to secure your instance.
+
+**How to configure:**
+
+1.  Open your `.env` file, creating it from `.env.example` if it doesn't exist.
+2.  Find the `AUTH_PASSWORD=` line.
+3.  Add a secure password to it. For example:
+    ```
+    AUTH_PASSWORD=your_super_secret_password_123
+    ```
+4.  Restart your server.
+
+Once set, all users will be prompted to enter this password before they can access the web interface. If this variable is left blank, this authentication method is disabled.
+
+---
+
+### Method 2: Self-settable Password
+
+This method allows the first user who accesses a new installation to set the password through the web interface. This is useful for initial deployments where you want an end-user to define their own credentials without needing access to the `.env` file.
+
+**How to configure:**
+
+1.  Open your `.env` file.
+2.  Find the `AUTH_SELFSET_PASSWORD=` line and set its value to `true`.
+    ```
+    AUTH_SELFSET_PASSWORD=true
+    ```
+3.  Restart your server.
+
+**How it works:**
+
+*   When this option is enabled, the first user to access the web interface will be greeted with a page to create a password.
+*   Once set, this password will be required for all subsequent access.
+*   The password file is stored securely at `data/keys/auth_password.key`. Ensure this path is included in your `.gitignore` file to prevent the password from being committed to version control.
+*   This method takes priority over the `AUTH_PASSWORD` variable. If `AUTH_SELFSET_PASSWORD` is `true`, the system will ignore any value in `AUTH_PASSWORD`.
+
+---
+
+### Disabling Authentication
+
+To disable password protection entirely, ensure both `AUTH_PASSWORD` is blank and `AUTH_SELFSET_PASSWORD` is `false` in your `.env` file. This is not recommended for instances exposed to a network. 

--- a/frontend/app/set-password/page.tsx
+++ b/frontend/app/set-password/page.tsx
@@ -83,6 +83,21 @@ export default function SetPasswordPage() {
             />
           </div>
 
+          <div className="rounded-md bg-yellow-50 p-4">
+            <div className="flex">
+              <div className="flex-shrink-0">
+                <svg className="h-5 w-5 text-yellow-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM10 13a1 1 0 110-2 1 1 0 010 2zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+                </svg>
+              </div>
+              <div className="ml-3">
+                <p className="text-sm text-yellow-800">
+                  Please write this password down. It <span className="font-bold">cannot</span> be reset or recovered if you lose it.
+                </p>
+              </div>
+            </div>
+          </div>
+
           {error && <p className="text-sm text-center text-red-600">{error}</p>}
 
           <div>

--- a/frontend/app/set-password/page.tsx
+++ b/frontend/app/set-password/page.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { setPassword } from '../../services/api';
+
+export default function SetPasswordPage() {
+  const [password, setPasswordState] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (password !== confirmPassword) {
+      setError('Passwords do not match.');
+      return;
+    }
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters long.');
+      return;
+    }
+    setIsLoading(true);
+    setError('');
+
+    const { success, message } = await setPassword(password);
+
+    if (success) {
+      // The backend sets the cookie, so we just need to go to the homepage.
+      // The middleware will be re-evaluated upon navigation.
+      router.push('/');
+      router.refresh(); 
+    } else {
+      setError(message || 'An unknown error occurred.');
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-50">
+      <div className="w-full max-w-md p-8 space-y-8 bg-white rounded-lg shadow-md">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold text-gray-900">Welcome to Brewdock</h1>
+          <p className="mt-2 text-gray-600">This is the first time you are running the application.</p>
+          <p className="mt-2 text-gray-600">Please set a password to secure your instance.</p>
+        </div>
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <div>
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-gray-700 sr-only"
+            >
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              value={password}
+              onChange={(e) => setPasswordState(e.target.value)}
+              className="w-full px-3 py-2 text-gray-900 placeholder-gray-500 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+              placeholder="Enter a password (min. 8 characters)"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="confirm-password"
+              className="block text-sm font-medium text-gray-700 sr-only"
+            >
+              Confirm Password
+            </label>
+            <input
+              id="confirm-password"
+              name="confirm-password"
+              type="password"
+              required
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className="w-full px-3 py-2 text-gray-900 placeholder-gray-500 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+              placeholder="Confirm your password"
+            />
+          </div>
+
+          {error && <p className="text-sm text-center text-red-600">{error}</p>}
+
+          <div>
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="w-full px-4 py-2 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:bg-indigo-400 disabled:cursor-not-allowed"
+            >
+              {isLoading ? 'Setting Password...' : 'Set Password and Login'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+} 

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,10 +1,15 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
-
-export const AUTH_COOKIE_NAME = "min_interns_auth_session";
+import { getAuthStatus, AuthStatus } from './services/api';
 
 // This salt must be the same as the one in the Python backend.
 const SESSION_SALT = "a1b2c3d4-e5f6-7890-a1b2-c3d4e5f67890";
+
+function getAuthCookieName(isSelfSet: boolean): string {
+    return isSelfSet 
+        ? "min_interns_auth_session_selfset" 
+        : "min_interns_auth_session_legacy";
+}
 
 async function get_session_token(password: string): Promise<string> {
   const token_source = `${SESSION_SALT}-${password}`;
@@ -24,38 +29,109 @@ async function get_session_token(password: string): Promise<string> {
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
-  const password = process.env.AUTH_PASSWORD;
-
-  // If authentication is not enabled, do nothing.
-  if (!password) {
+  
+  // Pass-through for API routes and static files
+  if (pathname.startsWith('/api') || pathname.startsWith('/_next')) {
     return NextResponse.next();
   }
 
-  const sessionCookie = request.cookies.get(AUTH_COOKIE_NAME);
+  // Environment variables are available in middleware
+  const isSelfSet = process.env.AUTH_SELFSET_PASSWORD === 'true';
+  const legacyPassword = process.env.AUTH_PASSWORD;
+  const authCookieName = getAuthCookieName(isSelfSet);
+
+  let authStatus: AuthStatus;
+
+  if (isSelfSet) {
+    // In self-set mode, we MUST query the backend to know if a password has been created.
+    // The request to /api/auth/status is excluded by the matcher config and won't loop.
+    const statusResponse = await fetch(new URL('/api/auth/status', request.url));
+    if (statusResponse.ok) {
+      const data = await statusResponse.json();
+      authStatus = data.status;
+    } else {
+      // If the backend is down, we can't determine status. 
+      // We can show a generic error or let it fail. For now, we'll treat as unconfigured.
+      authStatus = 'unconfigured';
+    }
+  } else {
+    authStatus = legacyPassword ? 'legacy_configured' : 'unconfigured';
+  }
+  
+  const isConfigured = authStatus === 'legacy_configured' || authStatus === 'self_set_configured';
+  const needsSetup = authStatus === 'self_set_unconfigured';
+
+  const sessionCookie = request.cookies.get(authCookieName);
+  const loginUrl = new URL('/login', request.url);
+  const setupUrl = new  URL('/set-password', request.url);
+  const homeUrl = new URL('/', request.url);
+
+
+  // State 1: Application needs initial password setup
+  if (needsSetup) {
+    if (pathname !== '/set-password') {
+      return NextResponse.redirect(setupUrl);
+    }
+    return NextResponse.next();
+  }
+
+  // State 2: Application is not configured and not in self-set mode. No protection.
+  if (!isConfigured) {
+    return NextResponse.next();
+  }
+
+  // State 3: Application is configured. Protect all routes.
+  const password = isSelfSet ? '' : legacyPassword; // For legacy, we need password to validate token.
 
   // If there's no cookie, redirect to login.
   if (!sessionCookie) {
     if (pathname !== '/login') {
-      return NextResponse.redirect(new URL('/login', request.url));
+      return NextResponse.redirect(loginUrl);
     }
     return NextResponse.next();
   }
 
   // If there IS a cookie, validate it.
-  const expectedToken = await get_session_token(password);
-  
-  // Using a simple equality check is fine here, as the source of expectedToken is secure.
-  if (sessionCookie.value !== expectedToken) {
-    // The cookie is invalid. Redirect to login and delete the bad cookie.
-    const response = NextResponse.redirect(new URL('/login', request.url));
-    response.cookies.delete(AUTH_COOKIE_NAME);
-    return response;
+  if (isSelfSet) {
+    // In self-set mode, we MUST ask the backend to verify the token, as only
+    // the backend knows the current password to validate the signature.
+    const verifyUrl = new URL('/api/auth/verify', request.url);
+    const verifyResponse = await fetch(verifyUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: sessionCookie.value }),
+    });
+
+    if (verifyResponse.ok) {
+        const data = await verifyResponse.json();
+        if (data.valid !== true) {
+            // The cookie is invalid (e.g., password changed). Delete it and redirect to login.
+            const response = NextResponse.redirect(loginUrl);
+            response.cookies.delete(authCookieName);
+            return response;
+        }
+    } else {
+        // If the verify endpoint fails, invalidate the session for security.
+        const response = NextResponse.redirect(loginUrl);
+        response.cookies.delete(authCookieName);
+        return response;
+    }
+
+  } else if (password) {
+    // For legacy mode, we can validate the token directly in the middleware.
+    const expectedToken = await get_session_token(password);
+    if (sessionCookie.value !== expectedToken) {
+      // The cookie is invalid. Redirect to login and delete the bad cookie.
+      const response = NextResponse.redirect(loginUrl);
+      response.cookies.delete(authCookieName);
+      return response;
+    }
   }
   
   // The cookie is valid.
-  // If the user tries to access the login page, redirect them to the home page.
-  if (pathname === '/login') {
-    return NextResponse.redirect(new URL('/', request.url));
+  // If the user tries to access login or setup, redirect them to the home page.
+  if (pathname === '/login' || pathname === '/set-password') {
+    return NextResponse.redirect(homeUrl);
   }
 
   // Otherwise, allow them to proceed.

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -16,6 +16,58 @@ export const login = async (password: string): Promise<boolean> => {
   }
 };
 
+export type AuthStatus = "self_set_configured" | "self_set_unconfigured" | "legacy_configured" | "unconfigured";
+
+export const getAuthStatus = async (): Promise<AuthStatus> => {
+  try {
+    const response = await fetch(`${API_URL}/auth/status`, { cache: 'no-store' });
+    if (!response.ok) {
+      return "unconfigured";
+    }
+    const data = await response.json();
+    return data.status;
+  } catch (error) {
+    console.error('Auth status request failed:', error);
+    return "unconfigured";
+  }
+};
+
+export const setPassword = async (password: string): Promise<{success: boolean, message?: string}> => {
+  try {
+    const response = await fetch(`${API_URL}/auth/set-password`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password }),
+    });
+    if (response.ok) {
+      return { success: true };
+    }
+    const errorData = await response.json();
+    return { success: false, message: errorData.detail || 'Failed to set password.' };
+  } catch (error) {
+    console.error('Set password request failed:', error);
+    return { success: false, message: 'An unexpected error occurred.' };
+  }
+};
+
+export const verifyToken = async (token: string): Promise<boolean> => {
+  try {
+    const response = await fetch(`${API_URL}/auth/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+    if (!response.ok) {
+      return false;
+    }
+    const data = await response.json();
+    return data.valid === true;
+  } catch (error) {
+    console.error('Token verification request failed:', error);
+    return false;
+  }
+};
+
 // --- End Auth ---
 
 export interface AppSettings {

--- a/mcp_servers/imap_mcpserver/src/imap_client/internals/connection_manager.py
+++ b/mcp_servers/imap_mcpserver/src/imap_client/internals/connection_manager.py
@@ -24,14 +24,26 @@ class FolderResolver:
     Uses RFC 6154 "SPECIAL-USE" attributes and falls back to guessing.
     An instance of this class is tied to a single IMAP connection.
     """
-    SPECIAL_USE_ATTRIBUTES = {'\\All', '\\Drafts', '\\Sent', '\\Junk', '\\Trash'}
+    SPECIAL_USE_ATTRIBUTES = {
+        '\\All', 
+        '\\Drafts', 
+        '\\Sent', 
+        '\\Junk', 
+        '\\Trash',
+        # Gmail-specific special use folders
+        '\\Important', # Important messages
+        '\\Flagged'    # Starred messages
+    }
     FALLBACK_MAP = {
-        '\\Sent': ('Sent', '[Gmail]/Sent Mail', 'Sent Items'),
+        '\\Sent': ('Sent', '[Gmail]/Sent Mail', 'Sent Items', 'Verzonden'),
         '\\Drafts': ('Drafts', '[Gmail]/Drafts'),
         '\\All': ('All Mail', '[Gmail]/All Mail'),
-        '\\Trash': ('Trash', '[Gmail]/Trash', 'Deleted Items'),
+        '\\Trash': ('Trash', '[Gmail]/Trash', 'Deleted Items', 'Prullenbak'),
         '\\Junk': ('Junk', 'Spam'),
-        '\\Inbox': ('INBOX',) # Inbox is a special case
+        '\\Inbox': ('INBOX',), # Inbox is a special case
+        # Fallbacks for Gmail's special folders
+        '\\Important': ('Important', '[Gmail]/Important'),
+        '\\Flagged': ('Starred', '[Gmail]/Starred')
     }
 
     def __init__(self, mail: imaplib.IMAP4_SSL):


### PR DESCRIPTION
### Summary

This pull request introduces a new authentication method allowing users to set their own password on the first run of the application. This enhances security and simplifies initial setup. Additionally, it refactors the label description generation logic to be more comprehensive and improves IMAP folder discovery.

### Changes

**Feature:**

*   **Self-settable Password:**
    *   Introduced a new `AUTH_SELFSET_PASSWORD` environment variable to enable a one-time, self-service password setup flow.
    *   The password is encrypted and stored in `data/keys/auth_password.key`.
    *   Relevant files: `api/endpoints/auth.py`, `frontend/middleware.ts`, `frontend/app/set-password/page.tsx`, `frontend/services/api.ts`.
*   **New Authentication Endpoints:**
    *   Added `/auth/status` to check the current authentication configuration.
    *   Added `/auth/set-password` to allow the first user to set the instance password.
    *   Added `/auth/verify` to validate session tokens against the currently active password.
    *   Relevant file: `api/endpoints/auth.py`.

**Refactor:**

*   **Label Description Generation:**
    *   The `generate_descriptions_for_agent` background task now overwrites existing labeling rules and populates them from all available inbox labels, ensuring descriptions are always generated for all user-defined labels.
    *   Relevant file: `api/background_tasks/label_description_generator.py`.
*   **IMAP Folder Discovery:**
    *   Enhanced the `FolderResolver` to recognize more special-use folder attributes (e.g., `\Important`, `\Flagged`) and added fallbacks for non-English folder names (e.g., 'Verzonden').
    *   Relevant file: `mcp_servers/imap_mcpserver/src/imap_client/internals/connection_manager.py`.

**Documentation:**

*   **Password Setup Guide:**
    *   Created a new guide explaining the two authentication methods (fixed vs. self-set).
    *   Relevant file: `documentation/set_passwords.md`.
*   **README Update:**
    *   Updated the main `README.md` to link to the new security documentation.

**Chore:**

*   **`.gitignore`:**
    *   Added `.auth_password.key` and `.key` to prevent sensitive files from being committed.
    *   Relevant file: `.gitignore`. 