### PR TITLE
Feat: Improve IMAP Password UX and Help Text

### DIFF
--- a/documentation/PR_description_drafts/2025-08-04-v0.1.1-dev-Improve-IMAP-Password-UX.md
+++ b/documentation/PR_description_drafts/2025-08-04-v0.1.1-dev-Improve-IMAP-Password-UX.md
@@ -1,0 +1,16 @@
+### Title: Feat: Improve IMAP Password UX and Help Text
+
+### Summary
+
+This pull request enhances the user experience related to IMAP configuration by clarifying the Google App Password process. It updates the help text to be more direct and adds a contextual warning in the settings UI to prevent users from entering their regular Google password.
+
+### Changes
+
+-   **Feat:**
+    -   In `frontend/components/settings/ImapSettings.tsx`, a warning message "This is not your regular Google Password!" is now displayed if the entered password does not conform to the 16-character format of a Google App Password. This warning is conditionally rendered based on the input's length after removing spaces.
+    -   The `lucide-react` import was updated to include `AlertCircle` for the new warning icon.
+
+-   **Docs:**
+    -   The help component `frontend/components/help/GoogleAppPasswordHelp.tsx` has been updated to simplify the instructions for generating a Google App Password.
+    -   The previous multi-step navigation guide is replaced with a direct link to the App Passwords page.
+    -   An informational note was added, reminding users that 2-Step Verification must be enabled and that company accounts may have restrictions on App Passwords.

--- a/frontend/components/help/GoogleAppPasswordHelp.tsx
+++ b/frontend/components/help/GoogleAppPasswordHelp.tsx
@@ -52,15 +52,18 @@ const GoogleAppPasswordHelp: React.FC<GoogleAppPasswordHelpProps> = ({ onClose }
       <div className={settingsSectionClasses}>
         <h2 className="text-2xl font-bold mb-3">Step 2: Create your App Password</h2>
         <ol className="list-decimal list-inside space-y-2">
-          <li>Go to your Google Account's <a href="https://myaccount.google.com/security" target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:underline">Security settings</a>.</li>
-          <li>Under "How you sign in to Google," find and click on "2-Step Verification". You might need to sign in again.</li>
-          <li>Scroll down to the bottom and click on "App passwords".</li>
           <li>
-            When asked to "Select app", choose "Other (Custom name)" and give it a name you'll remember, like "My AI Agent".
+            Go to the Google App Passwords page: <a href="https://myaccount.google.com/apppasswords" target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:underline">https://myaccount.google.com/apppasswords</a>.
+          </li>
+          <li>
+            Create a new app password and give it a name you'll remember, like "Brewdock".
           </li>
           <li>Click "Generate". Google will show you a 16-character password.</li>
           <li className="font-bold">Copy this password immediately. Google won't show it to you again. Do not store it anywhere, only paste it into the settings page.</li>
         </ol>
+        <p className="mt-4 p-3 bg-gray-100 rounded-lg text-sm text-gray-700">
+          <strong>Note:</strong> You must have 2-Step Verification enabled on your account (see Step 1). If you are using a company Google account, your administrator must have enabled the option to use App Passwords.
+        </p>
       </div>
 
       <div className={settingsSectionClasses}>

--- a/frontend/components/settings/ImapSettings.tsx
+++ b/frontend/components/settings/ImapSettings.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect } from 'react';
-import { Copy, HelpCircle } from 'lucide-react';
+import { Copy, HelpCircle, AlertCircle } from 'lucide-react';
 import { 
     AppSettings, 
     EmbeddingModel, 
@@ -37,6 +37,7 @@ const ImapSettings: React.FC<ImapSettingsProps> = ({
     const [toneAnalysisStatus, setToneAnalysisStatus] = useState<string | null>(null);
     const [toneAnalysisMessage, setToneAnalysisMessage] = useState<string>('');
     const [showGmailWarning, setShowGmailWarning] = useState(false);
+    const [showAppPasswordFormatWarning, setShowAppPasswordFormatWarning] = useState(false);
 
     const hasUnsavedChanges = JSON.stringify(settings) !== JSON.stringify(initialSettings);
 
@@ -134,6 +135,16 @@ const ImapSettings: React.FC<ImapSettingsProps> = ({
             fetchToneProfile();
         }
       }, [toneAnalysisStatus]);
+
+      useEffect(() => {
+        const password = settings.IMAP_PASSWORD || '';
+        if (password) {
+            const passwordWithoutSpaces = password.replace(/\s/g, '');
+            setShowAppPasswordFormatWarning(passwordWithoutSpaces.length !== 16);
+        } else {
+            setShowAppPasswordFormatWarning(false);
+        }
+      }, [settings.IMAP_PASSWORD]);
 
       const handleSave = async () => {
         setSaveStatus('saving');
@@ -288,7 +299,13 @@ const ImapSettings: React.FC<ImapSettingsProps> = ({
             <label className={labelClasses} htmlFor="imap-password">IMAP Password:</label>
             <div className="flex-1">
             <input className={inputClasses} type="password" id="imap-password" name="IMAP_PASSWORD" value={settings.IMAP_PASSWORD || ''} onChange={handleInputChange} />
-            <div className="flex items-center mt-1">
+            <div className="mt-1">
+                {showAppPasswordFormatWarning && (
+                    <button onClick={() => setHelpPanelOpen(true)} className="flex items-center text-xs text-red-600 hover:underline font-bold mb-1">
+                        <AlertCircle size={14} className="mr-1" />
+                        This is not your regular Google Password!
+                    </button>
+                )}
                 <button onClick={() => setHelpPanelOpen(true)} className="flex items-center text-xs text-blue-500 hover:underline">
                 <HelpCircle size={14} className="mr-1" />
                 Where to find your gmail App Password


### PR DESCRIPTION
### Summary

This pull request enhances the user experience related to IMAP configuration by clarifying the Google App Password process. It updates the help text to be more direct and adds a contextual warning in the settings UI to prevent users from entering their regular Google password.

### Changes

-   **Feat:**
    -   In `frontend/components/settings/ImapSettings.tsx`, a warning message "This is not your regular Google Password!" is now displayed if the entered password does not conform to the 16-character format of a Google App Password. This warning is conditionally rendered based on the input's length after removing spaces.
    -   The `lucide-react` import was updated to include `AlertCircle` for the new warning icon.

-   **Docs:**
    -   The help component `frontend/components/help/GoogleAppPasswordHelp.tsx` has been updated to simplify the instructions for generating a Google App Password.
    -   The previous multi-step navigation guide is replaced with a direct link to the App Passwords page.
    -   An informational note was added, reminding users that 2-Step Verification must be enabled and that company accounts may have restrictions on App Passwords.