### PR TITLE
fix(auth): Ensure default user exists and scope balance checks

### DIFF
--- a/documentation/PR_description_drafts/2025-08-05-v0.1.1-dev-fix(auth)-Ensure-default-user-exists-and-scope-balance-checks.md
+++ b/documentation/PR_description_drafts/2025-08-05-v0.1.1-dev-fix(auth)-Ensure-default-user-exists-and-scope-balance-checks.md
@@ -1,0 +1,18 @@
+### Title: fix(auth): Ensure default user exists and scope balance checks
+
+### Summary:
+
+This pull request resolves a critical "User not found" error that occurred in "no-auth" mode by ensuring a persistent default user record is always available. It also refactors the balance management system to exclusively apply to Auth0 users, preventing unintended balance checks for non-Auth0 users.
+
+### Changes:
+
+- **Fix:**
+    - Implemented a `get_or_create_default_user` function to guarantee the existence of a default user, resolving a race condition and preventing crashes in non-authenticated modes. (`user/internals/database.py`, `user/client.py`)
+    - Updated the `get_current_user` dependency to use this new function, standardizing user retrieval for password-based and no-auth modes. (`api/endpoints/auth.py`)
+
+- **Refactor:**
+    - Scoped the `check_user_balance` and `deduct_from_balance` functions to only execute for users with an `auth0_sub`, effectively limiting balance management to Auth0-authenticated users. (`user/client.py`)
+
+- **Chore:**
+    - Removed the now-redundant `get_default_user` and `get_default_system_user` functions to clean up the codebase. (`user/internals/database.py`, `user/client.py`)
+    - Removed extraneous logging of sensitive values from `shared/security/encryption.py` and `shared/app_settings.py`. 

--- a/shared/app_settings.py
+++ b/shared/app_settings.py
@@ -103,7 +103,6 @@ def load_app_settings(user_uuid: UUID) -> AppSettings:
     # Decrypt sensitive fields if they exist
     try:
         if settings_data.get("IMAP_PASSWORD"):
-            logger.info(f"DECRYPTION_DEBUG (app_settings): Raw IMAP_PASSWORD from Redis: '{settings_data['IMAP_PASSWORD']}'")
             settings_data["IMAP_PASSWORD"] = decrypt_value(settings_data["IMAP_PASSWORD"])
     except Exception as e:
         logger.error(f"An unexpected error occurred during settings decryption: {e}", exc_info=True)

--- a/shared/security/encryption.py
+++ b/shared/security/encryption.py
@@ -29,7 +29,7 @@ def get_encryption_key() -> bytes:
     
     global _ENCRYPTION_KEY
     if _ENCRYPTION_KEY:
-        logger.info(f"[PID: {pid}] Returning cached key: {_ENCRYPTION_KEY[:8]}...")
+        logger.info(f"[PID: {pid}] Returning cached key: {_ENCRYPTION_KEY[:4]}...")
         return _ENCRYPTION_KEY
 
     # The key is read outside the lock to allow for concurrent reads.
@@ -39,7 +39,7 @@ def get_encryption_key() -> bytes:
         with open(KEY_FILE_PATH, "rb") as key_file:
             key = key_file.read()
         _ENCRYPTION_KEY = key
-        logger.info(f"[PID: {pid}] Loaded key from disk: {key[:8]}...")
+        logger.info(f"[PID: {pid}] Loaded key from disk: {key[:4]}...")
         return key
 
     lock_file_path = KEY_FILE_PATH + ".lock"
@@ -109,7 +109,7 @@ def decrypt_value(encrypted_value: str) -> str:
         The decrypted plaintext string.
     """
     pid = os.getpid()
-    logger.info(f"DECRYPTION_DEBUG (encryption): Value received for decryption: '{encrypted_value}'")
+    logger.info(f"DECRYPTION_DEBUG (encryption): Value received for decryption: '{encrypted_value[:4]}...{encrypted_value[-4:]}'")
     if not encrypted_value:
         return encrypted_value
         

--- a/user/client.py
+++ b/user/client.py
@@ -1,6 +1,6 @@
 from typing import Optional, Dict, Any
 from user.internals.database import (
-    get_default_user as get_default_user_from_db,
+    get_or_create_default_user as get_or_create_default_user_from_db,
     create_user as create_user_in_db,
     get_user_by_uuid as get_user_by_uuid_from_db,
     find_or_create_user_by_auth0_sub as find_or_create_user_by_auth0_sub_in_db,
@@ -13,12 +13,12 @@ from user.exceptions import InsufficientBalanceError
 from uuid import uuid4, UUID
 from datetime import datetime, timezone
 
-def get_default_system_user() -> Optional[User]:
+def get_or_create_default_user() -> User:
     """
-    Retrieves the single, shared user record for password-based authentication mode.
+    Retrieves the single, shared user record, creating it if it doesn't exist.
     This is a passthrough to the internal database function.
     """
-    return get_default_user_from_db()
+    return get_or_create_default_user_from_db()
 
 def get_user_by_uuid(user_uuid: UUID) -> Optional[User]:
     """Retrieves a user from the database by their UUID."""
@@ -30,22 +30,38 @@ def find_or_create_user_by_auth0_sub(auth0_sub: str, email: Optional[str] = None
 
 def check_user_balance(user_id: UUID):
     """
-    Checks a user's balance. Raises an exception if the balance is depleted.
+    Checks a user's balance if they are an Auth0 user.
+    Raises an exception if the balance is depleted.
+    Non-Auth0 users will always pass this check.
     """
     user = get_user_by_uuid_from_db(user_id)
     if not user:
-        # Or handle as a different error, but for now, this is a safe default
         raise ValueError("User not found")
-    if user.balance <= 0:
-        raise InsufficientBalanceError()
+
+    # Only check balance for Auth0 users
+    if user.auth0_sub:
+        if user.balance <= 0:
+            raise InsufficientBalanceError()
 
 def set_user_balance(user_uuid: UUID, new_balance: float) -> Optional[User]:
     """Updates the balance for a specific user."""
     return set_user_balance_in_db(user_uuid, new_balance)
 
 def deduct_from_balance(user_uuid: UUID, cost: float) -> Optional[User]:
-    """Deducts a cost from a user's balance."""
-    return deduct_from_balance_in_db(user_uuid, cost)
+    """
+    Deducts a cost from a user's balance if they are an Auth0 user.
+    """
+    user = get_user_by_uuid_from_db(user_uuid)
+    if not user:
+        # We don't raise an error here to avoid crashing a running process
+        # if the user somehow gets deleted mid-operation.
+        return None
+
+    # Only deduct from balance for Auth0 users
+    if user.auth0_sub:
+        return deduct_from_balance_in_db(user_uuid, cost)
+    
+    return user # Return the original user object if no deduction was made
 
 def get_all_users() -> list[User]:
     """Retrieves all users."""


### PR DESCRIPTION
### Summary:

This pull request resolves a critical "User not found" error that occurred in "no-auth" mode by ensuring a persistent default user record is always available. It also refactors the balance management system to exclusively apply to Auth0 users, preventing unintended balance checks for non-Auth0 users.

### Changes:

- **Fix:**
    - Implemented a `get_or_create_default_user` function to guarantee the existence of a default user, resolving a race condition and preventing crashes in non-authenticated modes. (`user/internals/database.py`, `user/client.py`)
    - Updated the `get_current_user` dependency to use this new function, standardizing user retrieval for password-based and no-auth modes. (`api/endpoints/auth.py`)

- **Refactor:**
    - Scoped the `check_user_balance` and `deduct_from_balance` functions to only execute for users with an `auth0_sub`, effectively limiting balance management to Auth0-authenticated users. (`user/client.py`)

- **Chore:**
    - Removed the now-redundant `get_default_user` and `get_default_system_user` functions to clean up the codebase. (`user/internals/database.py`, `user/client.py`)
    - Removed extraneous logging of sensitive values from `shared/security/encryption.py` and `shared/app_settings.py`. 