### PR TITLE
feat(auth): Redirect to login on session expiry and add debug logging

### DIFF
--- a/api/endpoints/auth.py
+++ b/api/endpoints/auth.py
@@ -103,6 +103,7 @@ async def get_current_user(
     if settings.AUTH0_DOMAIN and settings.AUTH0_DOMAIN.strip():
         if token is None:
             print("[AUTH_DEBUG] Auth0 mode: Token is missing.")
+            print(f"[AUTH_DEBUG] Request details: client={request.client} headers={dict(request.headers)}")
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Not authenticated",

--- a/frontend/app/workflows/page.tsx
+++ b/frontend/app/workflows/page.tsx
@@ -49,6 +49,7 @@ const WorkflowsPage = () => {
   };
 
   useEffect(() => {
+    console.log('[DEBUG] WorkflowsPage: Attempting to call fetchWorkflows()');
     fetchWorkflows();
   }, []);
 

--- a/frontend/components/TopBar.tsx
+++ b/frontend/components/TopBar.tsx
@@ -15,6 +15,7 @@ const TopBar: React.FC<TopBarProps> = () => {
 
   useEffect(() => {
     getClientAuthMode().then(setAuthMode);
+    console.log('[DEBUG] TopBar: Attempting to call getMe()');
     getMe().then(setUser);
   }, []);
   

--- a/frontend/components/settings/ImapSettings.tsx
+++ b/frontend/components/settings/ImapSettings.tsx
@@ -209,6 +209,7 @@ const ImapSettings: React.FC<ImapSettingsProps> = ({
           setTestStatus('success');
           setTestMessage(result.message);
         } catch (error: any) {
+          console.error("[DEBUG] Caught error in 'handleTestConnection':", error);
           setTestStatus('error');
           setTestMessage(error.message || 'An unknown error occurred.');
         }

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -43,6 +43,7 @@ export const getClientAuthMode = (): Promise<'auth0' | 'password' | 'none'> => {
 
 // A centralized fetch wrapper to handle adding the auth token
 export const apiFetch = async (url: string, options: RequestInit = {}) => {
+  console.log(`[DEBUG] apiFetch called for URL: ${url}`);
   const mode = await getClientAuthMode();
   let token: string | undefined;
 
@@ -52,10 +53,15 @@ export const apiFetch = async (url: string, options: RequestInit = {}) => {
       const tokenResult = await getAccessToken();
       if (typeof tokenResult === 'string') {
         token = tokenResult;
+        console.log(`[DEBUG] Successfully attached token for: ${url}`);
       }
     } catch (e: any) {
-      console.error("[apiFetch] Error getting access token:", e);
-      console.warn("Could not get access token", e.message);
+      console.error(`[DEBUG] FAILED to get access token for ${url}:`, e);
+      // The session is invalid, redirect to the login page.
+      // This should only happen in the browser.
+      if (typeof window !== 'undefined') {
+        window.location.href = '/login';
+      }
     }
   }
 
@@ -148,7 +154,7 @@ export const getMe = async (): Promise<UserProfile | null> => {
   try {
     return await jsonApiFetch(`${API_URL}/users/me`);
   } catch (error) {
-    console.error('An error occurred while fetching user profile:', error);
+    console.error('[DEBUG] IN CATCH BLOCK of getMe(): An error occurred while fetching user profile. This will return null.', error);
     return null;
   }
 };
@@ -307,7 +313,7 @@ export const testImapConnection = async () => {
     console.log('Successfully tested IMAP connection:', result);
     return result;
   } catch (error) {
-    console.error('An error occurred while testing IMAP connection:', error);
+    console.error('[DEBUG] IN CATCH BLOCK of testImapConnection():', error);
     throw error;
   }
 };


### PR DESCRIPTION
- Add a redirect to the login page in the global apiFetch function when an access token cannot be retrieved.
- Add detailed logging to the frontend API service and components to trace the lifecycle of API calls during page load.
- Add request header logging to the backend get_current_user dependency to identify the source of unauthenticated API calls.