### PR TITLE
feat: Implement reliable Gmail archiving with remove_from_inbox tool

### DIFF
--- a/documentation/plans/2025-08-06-implement-email-label-removal-via-imap.md
+++ b/documentation/plans/2025-08-06-implement-email-label-removal-via-imap.md
@@ -1,0 +1,57 @@
+# Email Archive Implementation Summary
+
+**Date**: 2025-08-06  
+**Status**: ✅ **COMPLETED AND DEPLOYED**
+
+## 🎯 Features Implemented
+
+### **Primary Tool Added**
+1. **`remove_from_inbox(messageId)`** - Reliable Gmail archiving (COPY+DELETE+EXPUNGE to All Mail)
+
+## 📁 Implementation Summary
+
+### Backend (client.py)
+- `_remove_from_inbox_sync()` + `remove_from_inbox()` async wrapper
+
+### MCP Tools (imap.py)
+- `remove_from_inbox(messageId)` - Archives to [Gmail]/All Mail
+
+## 💡 Usage Examples
+```python
+# Archive email (remove from inbox)
+remove_from_inbox("msg@gmail.com")
+```
+
+---
+
+## 🚨 Issues Encountered & Resolved
+
+### **Issue 1: Label-Based Archive Failure**
+**Problem**: Original `archive_message` function failed due to IMAP response parsing bugs  
+**Root Cause**: Gmail's IMAP responses mixed quoted/unquoted labels, breaking regex parsing  
+**Solution**: Replaced with move-based approach using COPY+DELETE+EXPUNGE pattern
+
+## ✅ Current Tool Status
+
+**Active Tools (6 total)**:
+- `remove_from_inbox` - **NEW** reliable Gmail archiving  
+- `draft_reply`, `set_label`, `get_thread_for_message_id`, `list_most_recent_inbox_emails`, `find_similar_threads`
+
+**Removed Tools**:  
+- `archive_message` (buggy IMAP parsing) → replaced by `remove_from_inbox`
+- `archive_email_from_inbox` (unreliable) → replaced by `remove_from_inbox`
+
+---
+
+## ⚠️ Technical Notes
+
+**Implementation Method**: COPY + DELETE + EXPUNGE pattern
+- Copies message to [Gmail]/All Mail  
+- Marks original as deleted in source location
+- Expunges to complete the move
+- **Result**: Reliable inbox removal with message preserved in All Mail
+
+**Error Handling**: 
+- Invalid message ID returns proper error message
+
+**Destructive Operation Warning**: Original email is permanently deleted from source mailbox after expunge (but preserved in All Mail)

--- a/mcp_servers/imap_mcpserver/src/tools/imap.py
+++ b/mcp_servers/imap_mcpserver/src/tools/imap.py
@@ -11,7 +11,7 @@ from email_reply_parser import EmailReplyParser
 
 from ..mcp_builder import mcp_builder
 from ..dependencies import get_context_from_headers
-from ..imap_client.client import get_message_by_id, get_complete_thread, draft_reply as client_draft_reply, set_label as client_set_label, get_recent_inbox_messages, get_all_labels
+from ..imap_client.client import get_message_by_id, get_complete_thread, draft_reply as client_draft_reply, set_label as client_set_label, get_recent_inbox_messages, get_all_labels, remove_from_inbox as client_remove_from_inbox
 from shared.qdrant.qdrant_client import semantic_search, search_by_vector, generate_qdrant_point_id
 from shared.services.embedding_service import get_embedding, rerank_documents
 from shared.app_settings import load_app_settings
@@ -50,6 +50,26 @@ async def set_label(messageId: str, label: str) -> Dict[str, Any]:
         return {"success": False, "message": "messageId and label are required."}
 
     result = await client_set_label(user_uuid=context.user_id, message_id=messageId, label=label)
+    return result
+
+@mcp_builder.tool()
+async def remove_from_inbox(messageId: str) -> Dict[str, Any]:
+    """
+    Skips the inbox for a Gmail message by moving it directly to All Mail.
+    This simulates Gmail's "Skip Inbox" feature - the email will be archived
+    and won't appear in the inbox but will still be accessible in All Mail.
+    
+    Args:
+        messageId: The Message-ID header of the email to skip inbox for
+    
+    Returns:
+        Dict with status and message indicating success or failure
+    """
+    context = get_context_from_headers()
+    result = await client_remove_from_inbox(
+        user_uuid=context.user_id,
+        message_id=messageId
+    )
     return result
 
 @mcp_builder.tool()


### PR DESCRIPTION
# Implement reliable Gmail archiving with remove_from_inbox tool

## Summary

This implementation adds a reliable Gmail message archiving mechanism to the IMAP MCP server. The new `remove_from_inbox` tool replaces previous unreliable label-based archiving approaches with a robust COPY+DELETE+EXPUNGE pattern that moves messages from their current location to Gmail's All Mail folder.

Closes [Issue #35](https://github.com/Itempass/brewdock/issues/35)

## Changes

### Feature: New Gmail Archiving Tool
- **`mcp_servers/imap_mcpserver/src/tools/imap.py`**: Add `remove_from_inbox` MCP tool that simulates Gmail's "Skip Inbox" feature
- **`mcp_servers/imap_mcpserver/src/imap_client/client.py`**: Add `_remove_from_inbox_sync` synchronous implementation and `remove_from_inbox` async wrapper
- **`mcp_servers/imap_mcpserver/src/imap_client/client.py`**: Update import statement to include the new `remove_from_inbox` client function

### Technical Implementation
- Uses IMAP COPY+DELETE+EXPUNGE pattern to reliably move messages to [Gmail]/All Mail
- Provides proper error handling for invalid message IDs and IMAP operation failures
- Maintains message accessibility in All Mail while removing from current mailbox
- Returns structured status responses with success/error messages

### Documentation
- **`documentation/plans/2025-08-06-implement-email-label-removal-via-imap.md`**: Add comprehensive implementation documentation covering technical approach, usage examples, and resolved issues with previous archiving methods