### PR TITLE
Add per-user IMAP concurrency guard and use shared connection helper

### DIFF
--- a/api/endpoints/connection.py
+++ b/api/endpoints/connection.py
@@ -5,6 +5,11 @@ from fastapi import APIRouter, HTTPException, Depends
 from shared.app_settings import load_app_settings
 from user.models import User
 from api.endpoints.auth import get_current_user
+from mcp_servers.imap_mcpserver.src.imap_client.internals.connection_manager import (
+    imap_connection,
+    IMAPConnectionError,
+    acquire_imap_slot,
+)
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -13,16 +18,23 @@ logger = logging.getLogger(__name__)
 async def test_imap_connection(current_user: User = Depends(get_current_user)):
     """
     Tests the connection to the IMAP server using settings from Redis for the current user.
+    Uses the shared connection helper and per-user concurrency limiter to avoid exceeding
+    provider connection limits.
     """
     try:
-        settings = load_app_settings(user_uuid=current_user.uuid)
-        if not all([settings.IMAP_SERVER, settings.IMAP_USERNAME, settings.IMAP_PASSWORD]):
+        app_settings = load_app_settings(user_uuid=current_user.uuid)
+        if not all([app_settings.IMAP_SERVER, app_settings.IMAP_USERNAME, app_settings.IMAP_PASSWORD]):
             raise HTTPException(status_code=400, detail="IMAP settings are not fully configured. Please save your settings first.")
 
-        mail = imaplib.IMAP4_SSL(settings.IMAP_SERVER)
-        mail.login(settings.IMAP_USERNAME, settings.IMAP_PASSWORD)
-        mail.logout()
+        # Respect per-user concurrency limits
+        async with acquire_imap_slot(current_user.uuid):
+            # Login/logout handled inside context manager
+            with imap_connection(app_settings=app_settings) as (_mail, _resolver):
+                pass
         return {"message": "IMAP connection successful."}
+    except IMAPConnectionError as e:
+        logger.error(f"IMAP connection failed: {e}")
+        raise HTTPException(status_code=400, detail=f"IMAP connection failed: {e}")
     except imaplib.IMAP4.error as e:
         logger.error(f"IMAP connection failed: {e}")
         raise HTTPException(status_code=400, detail=f"IMAP connection failed: {e}")
@@ -30,4 +42,4 @@ async def test_imap_connection(current_user: User = Depends(get_current_user)):
         raise e
     except Exception as e:
         logger.error(f"An unexpected error occurred during IMAP connection test: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {e}") 
+        raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {e}")


### PR DESCRIPTION
- update api/endpoints/connection.py to use imap_connection and acquire_imap_slot in test_imap_connection
- wrap get_recent_inbox_message_ids, get_message_by_id, get_complete_thread, get_recent_inbox_messages, get_recent_sent_messages, draft_reply, set_label, remove_from_inbox, get_emails, get_all_folders, get_all_special_use_folders, list_headers, list_headers_multi_with_counts, get_message_by_contextual_uid, list_recent_uids, count_uids with acquire_imap_slot in mcp_servers/imap_mcpserver/src/imap_client/client.py
- fix bulk helper variables in client.py by removing seen_thrids and unused batch flush paths
- guard export_threads_dataset_bulk, list_headers, and related executor calls with acquire_imap_slot in client.py
- import acquire_imap_slot and wrap MailBox(...).login(...) block in async with acquire_imap_slot(user.uuid) in triggers/main.py