### PR TITLE
Bugfix: Brewdock kept reloading

### DIFF
--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -24,6 +24,7 @@ export default async function LoginPage() {
             <p className="mt-2 text-sm text-gray-600">You will be redirected to our secure login provider.</p>
             <Link
                 href="/auth-client/login"
+                prefetch={false}
                 className="inline-block w-full px-4 py-3 text-sm font-semibold text-white bg-gray-900 border border-transparent rounded-lg shadow-sm hover:bg-black focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900 transition-all duration-200"
             >
                 Continue to Login

--- a/frontend/components/GlobalBalanceBanner.tsx
+++ b/frontend/components/GlobalBalanceBanner.tsx
@@ -7,6 +7,7 @@ const GlobalBalanceBanner: React.FC = () => {
   const [authMode, setAuthMode] = useState<'auth0' | 'password' | 'none'>('none');
   const [user, setUser] = useState<UserProfile | null>(null);
   const pathname = usePathname();
+  const shouldSkip = pathname === '/login' || pathname.startsWith('/auth-client');
 
   const load = async () => {
     const mode = await getClientAuthMode();
@@ -20,12 +21,14 @@ const GlobalBalanceBanner: React.FC = () => {
   };
 
   useEffect(() => {
+    if (shouldSkip) return;
     load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pathname]);
+  }, [pathname, shouldSkip]);
 
   useEffect(() => {
     const onVisibility = () => {
+      if (shouldSkip) return;
       if (document.visibilityState === 'visible') {
         load();
       }
@@ -33,9 +36,9 @@ const GlobalBalanceBanner: React.FC = () => {
     document.addEventListener('visibilitychange', onVisibility);
     return () => document.removeEventListener('visibilitychange', onVisibility);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [shouldSkip]);
 
-  if (authMode !== 'auth0' || !user || typeof user.balance !== 'number' || user.balance >= 2) {
+  if (shouldSkip || authMode !== 'auth0' || !user || typeof user.balance !== 'number' || user.balance >= 2) {
     return null;
   }
 


### PR DESCRIPTION
Issue 1: CORS errors on Auth0 during login link click

- Symptom: Console showed “blocked by CORS policy” and “Failed to fetch RSC payload… Falling back to browser navigation” when visiting /login.
- Root cause: Next.js Link auto-prefetch in production was prefetching '/auth-client/login'. That route immediately redirects to Auth0’s /authorize URL, which is cross-origin and not CORS-enabled. The prefetch request follows the redirect and gets blocked by the browser, producing the warning.
- Why “sudden” (we deployed this morning and tested, there were no issues. Now a couple hours later it stopped working even though there was no new deploy): Next prefetch is heuristic. Network/tab conditions in the earlier session likely prevented prefetch; later conditions allowed it, exposing the warning.
- Fix: Disable prefetch for the login link in frontend/app/login/page.tsx. Change: add prefetch={false} on the Link to '/auth-client/login'.


Issue 2: Access token fetch error on login page

- Symptom: “[DEBUG] FAILED to get access token for /api/users/me” on the /login page.
- Root cause: frontend/components/GlobalBalanceBanner.tsx calls getMe() on route change and visibility. On /login, there’s no Auth0 session yet, so getAccessToken() throws, triggering the debug log.
- Fix: Skip user fetches on unauthenticated routes. Change: In GlobalBalanceBanner, detect pathname === '/login' or pathname.startsWith('/auth-client') and skip getMe() plus hide the banner.